### PR TITLE
Migrate SqlClient

### DIFF
--- a/CommandRunner/CodeGeneration/TableConstantStatics.cs
+++ b/CommandRunner/CodeGeneration/TableConstantStatics.cs
@@ -16,7 +16,7 @@ namespace CommandRunner.CodeGeneration {
 						writer.WriteLine( "public class " + Utility.GetCSharpIdentifier( table.Name.TableNameToPascal( cn ) + "Table" ) + " {" );
 
 						CodeGenerationStatics.AddSummaryDocComment( writer, "The name of this table." );
-						writer.WriteLine( "public const string Name = \"" + table + "\";" );
+						writer.WriteLine( "public const string Name = \"" + table.ObjectIdentifier + "\";" );
 
 						foreach( var column in new TableColumns( cn, table.ObjectIdentifier, false ).AllColumnsExceptRowVersion ) {
 							CodeGenerationStatics.AddSummaryDocComment( writer, "Contains schema information about this column." );

--- a/TypedDataLayer/BuildDebugNugetPackage.ps1
+++ b/TypedDataLayer/BuildDebugNugetPackage.ps1
@@ -1,0 +1,4 @@
+﻿$now = Get-Date
+$version = [string]::Format("{0}.{1}.{2}.{3}$OctoVersionSuffix",$now.Year, $now.Month, $now.Day,$now.Hour*10000+$now.Minute*100+$now.Second)
+
+nuget.exe pack TypedDataLayer.nuspec -Prop Configuration=Debug -Version $version -Suffix alpha

--- a/TypedDataLayer/DataAccess/DBConnection.cs
+++ b/TypedDataLayer/DataAccess/DBConnection.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using StackExchange.Profiling;

--- a/TypedDataLayer/DataAccess/DataAccessMethods.cs
+++ b/TypedDataLayer/DataAccess/DataAccessMethods.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using TypedDataLayer.DataAccess.CommandWriting.InlineConditionAbstraction;

--- a/TypedDataLayer/DatabaseSpecification/Databases/SqlServerInfo.cs
+++ b/TypedDataLayer/DatabaseSpecification/Databases/SqlServerInfo.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using StackExchange.Profiling;
 using StackExchange.Profiling.Data;
 using TypedDataLayer.Tools;

--- a/TypedDataLayer/TypedDataLayer.csproj
+++ b/TypedDataLayer/TypedDataLayer.csproj
@@ -19,9 +19,9 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TypedDataLayer/TypedDataLayer.nuspec
+++ b/TypedDataLayer/TypedDataLayer.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>TypedDataLayer</id>
-		<version>0.0.0.0</version>
+		<version>120.0.0.0</version>
 		<title>TypedDataLayer</title>
 		<authors>Sam Rueby, William Gross, Greg Smalter</authors>
 		<owners>Sam Rueby</owners>

--- a/TypedDataLayer/TypedDataLayer.nuspec
+++ b/TypedDataLayer/TypedDataLayer.nuspec
@@ -16,14 +16,14 @@
 			<group targetFramework=".NETFramework4.6.1">
 				<dependency id="JetBrains.Annotations" version="10.3.0" exclude="Build,Analyzers" />
 				<dependency id="MiniProfiler.AspNetCore.Mvc" version="4.0.0" exclude="Build,Analyzers" />
-				<dependency id="System.Configuration.ConfigurationManager" version="4.5.0" exclude="Build,Analyzers" />
-				<dependency id="System.Data.SqlClient" version="4.4.0" exclude="Build,Analyzers" />
+				<dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Build,Analyzers" />
+				<dependency id="Microsoft.Data.SqlClient" version="2.1.2" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework=".netcoreapp2.1">
 				<dependency id="JetBrains.Annotations" version="10.3.0" exclude="Build,Analyzers" />
 				<dependency id="MiniProfiler.AspNetCore.Mvc" version="4.0.0" exclude="Build,Analyzers" />
-				<dependency id="System.Configuration.ConfigurationManager" version="4.5.0" exclude="Build,Analyzers" />
-				<dependency id="System.Data.SqlClient" version="4.4.0" exclude="Build,Analyzers" />
+				<dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Build,Analyzers" />
+				<dependency id="Microsoft.Data.SqlClient" version="2.1.2" exclude="Build,Analyzers" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/TypedDataLayer/packages.config
+++ b/TypedDataLayer/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-	<package id="JetBrains.Annotations" version="10.3.0" targetFramework="net451" />
-	<package id="MiniProfiler" version="3.2.0.157" targetFramework="net451" />
-</packages>


### PR DESCRIPTION
This pull request is a few things:

- Fixed a bug with latest schema feature
- Added a ps1 script to generate local debug packages
- Migrated from System.Data.SqlClient to Microsoft.Data.SqlClient.

The most important part of this (aside from fixing the bug) is migrating to Microsoft.Data.SqlClient. This is largely a namespace change. The most important reason to migrate is that System.Data.SqlClient does not support AD authentication. There should be no downsides to this. Read more about Microsoft.Data.SqlClient here: https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/ .